### PR TITLE
Short (wrong) CRC fixed by padding with "0".

### DIFF
--- a/crc16-modbus.js
+++ b/crc16-modbus.js
@@ -77,9 +77,8 @@ module.exports = function(RED) {
         Calculate: function(str, inputType) {
             this.StringToCheck = str;
             if (this.CleanString(inputType)) {
-                crcinputcrc16modbus=this.CRC16Modbus().toString(16).toUpperCase();
+                crcinputcrc16modbus=this.CRC16Modbus().toString(16).toUpperCase().padStart(4, "0");
                 crcinputcrc16modbus=crcinputcrc16modbus.substr(2) + crcinputcrc16modbus.substr(0, 2); //swap bytes
-       
             }
         }
     };


### PR DESCRIPTION
The CRC is calculated wrongly in case the CRC contains a "0" as the leftmost digit in the string representation (before the byte swap). This is fixed by padding the string with "0".